### PR TITLE
feature/remove-tag-handling

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -13,7 +13,6 @@ inputs:
 
 outputs:
   - name: build
-  - name: version
 
 run:
   path: dp-table-builder-ui/ci/scripts/build.sh

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -5,5 +5,3 @@ pushd dp-table-builder-ui
 popd
 
 cp -r dp-table-builder-ui/dist/* build/
-
-perl -ne '/version.+(\d+\.\d+\.\d+)/ && print qq(version-$1)' dp-table-builder-ui/package.json > version/version


### PR DESCRIPTION
We only push `master` to NPM and will now always tag this as the latest.