### PR TITLE
Make build output dp-table-builder-ui to preserve dist for npm publish

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -14,6 +14,7 @@ inputs:
 outputs:
   - name: build
   - name: package
+  - name: dp-table-builder-ui
 
 run:
   path: dp-table-builder-ui/ci/scripts/build.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dp-table-builder-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dp-table-builder-ui",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "babel-polyfill": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dp-table-builder-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "homepage": "https://www.npmjs.com/package/dp-table-builder-ui",
   "description": "Handsontable grid implementation",
   "main": "dist/index.js",


### PR DESCRIPTION
### What

- Recently moved from the `npm` pipeline to the `npm-pkg` pipeline
  - new pipeline runs the release job differently from the old pipeline

Release 1.3.0 did not include the `/dist` directory, causing errors when updating to v1.3.0 in Florence.

-  Fix for missing `/dist` in release 1.3.0
   - Optionally compare versions;
     - `npm pack dp-table-builder-ui@1.3.0 --dry-run` and `npm pack dp-table-builder-ui@1.2.0 --dry-run`

- `dist/` is gitignored so it is not present in a clean git checkout
- The [new pipeline release job](https://github.com/ONSdigital/dp-ci/blob/main/pipelines/pipeline-generator/pipelines/npm-pkg.yml#L392) fetches a clean checkout into a directory named `((repo_name))` (`dp-table-builder-ui`)
- The `build` task runs `make build` inside `dp-table-builder-ui/`, which generates `dist/` there
- However, `dp-table-builder-ui` was only declared as a task input, not an output so it is not preserved with `dist/`
- The [put: npm-repository](https://github.com/ONSdigital/dp-ci/blob/main/pipelines/pipeline-generator/pipelines/npm-pkg.yml#L409) step then published from `((repo_name))`, which no longer has `dist/`

This fix; declares `dp-table-builder-ui` as a task output. Which preserves it with `dist/` intact for the publish step.

### How to review

Sense check

### Who can review

!Me